### PR TITLE
Preferred date now dropdown

### DIFF
--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/request/new.html.eex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/request/new.html.eex
@@ -54,7 +54,7 @@
   <label class="field">
     <div>Is having the concert on a specific date really important?</div>
     <p class="negative">(Note: if a specific day isn’t essential, do not not fill out this date as that will increase our ability to book your request. If you do select a date and we can’t book that date, we won’t book your request).</p>
-    <%= request_date f, :preferred_date %>
+    <%= request_date f, :preferred_date, "Select Special Day (optional)" %>
   </label>
   <br/>
   <div>Which type of music would your nominee enjoy hearing at their Curbside Concert? (please check all that apply):  </div>

--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/views/request_view.ex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/views/request_view.ex
@@ -175,9 +175,30 @@ defmodule CurbsideConcertsWeb.RequestView do
     """
   end
 
-  def request_date(form, field) do
+  @months Enum.zip(
+            1..12,
+            ~w[January February March April May June July August September October November December]
+          )
+          |> Map.new()
+  @weekdays Enum.zip(1..7, ~w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday])
+            |> Map.new()
+  @spec request_date(atom | Phoenix.HTML.Form.t(), atom) :: {:safe, [...]}
+  def request_date(form, field, prompt \\ "Select a day") do
+    today = Date.utc_today()
+
+    prompt = {prompt, ""}
+
+    options =
+      1..90
+      |> Enum.map(fn n ->
+        date = Date.add(today, n)
+        weekday = Date.day_of_week(date)
+        display = "#{@weekdays[weekday]}, #{@months[date.month]} #{date.day}"
+        {display, "#{date}"}
+      end)
+
     ~E"""
-    <%= date_input(form, field, placeholder: "mm/dd/yyyy") %>
+    <%= select(form, field, [prompt | options]) %>
     <%= error_tag form, field %>
     """
   end

--- a/e2e/cypress/integration/request.spec.js
+++ b/e2e/cypress/integration/request.spec.js
@@ -23,7 +23,7 @@ const requestData = {
 	genres: [genreData1.name, genreData2.name],
 	nomineeStreetAddress: faker.address.streetAddress(),
 	nomineeCity: faker.address.city(),
-	nomineeZipCode: faker.address.zipCode(),
+	nomineeZipCode: faker.address.zipCode("#####"),
 	nomineeAddressNotes: faker.lorem.paragraph(),
 	specialMessage: faker.lorem.paragraph(),
 	requesterName: faker.name.findName(),
@@ -101,7 +101,7 @@ describe("Request", () => {
 
 			const streetAddress = faker.address.streetAddress();
 			const city = faker.address.city();
-			const zipCode = faker.address.zipCode();
+			const zipCode = faker.address.zipCode("#####");
 
 			requestEditPage.fillInNomineeStreetAddress(streetAddress);
 			requestEditPage.fillInNomineeCity(city);


### PR DESCRIPTION
Will consist of the 90 upcoming days from today.
The prior input was a type=“date” which isn’t supported in Safari or IE and trying to find decent polyfill was fruitless.