### PR TITLE
Admin notes

### DIFF
--- a/apps/curbside_concerts/lib/curbside_concerts/requests/request.ex
+++ b/apps/curbside_concerts/lib/curbside_concerts/requests/request.ex
@@ -11,7 +11,7 @@ defmodule CurbsideConcerts.Requests.Request do
   alias CurbsideConcerts.Musicians.Genre
   alias CurbsideConcerts.Requests.RequestGenre
 
-  @allowed_attrs ~w|state contact_preference nominee_name nominee_phone nominee_address nominee_street_address nominee_city nominee_zip_code nominee_address_notes special_message requester_name requester_phone requester_email rank session_id archived request_reason nominee_description special_message_sender_name nominee_favorite_music_notes request_occasion preferred_date nominee_email requester_relationship special_instructions requester_newsletter_interest priority|a
+  @allowed_attrs ~w|state contact_preference nominee_name nominee_phone nominee_address nominee_street_address nominee_city nominee_zip_code nominee_address_notes special_message requester_name requester_phone requester_email rank session_id archived request_reason nominee_description special_message_sender_name nominee_favorite_music_notes request_occasion preferred_date nominee_email requester_relationship special_instructions requester_newsletter_interest priority admin_notes|a
   @required_attrs ~w|state contact_preference nominee_name nominee_street_address nominee_city nominee_zip_code special_message requester_name requester_phone requester_email|a
 
   schema "requests" do
@@ -40,6 +40,7 @@ defmodule CurbsideConcerts.Requests.Request do
     field(:special_instructions, :string)
     field(:requester_newsletter_interest, :boolean, default: false)
     field(:priority, :boolean, default: false)
+    field(:admin_notes, :string)
 
     # deprecated fields
     field(:song, :string)

--- a/apps/curbside_concerts/priv/repo/migrations/20200510001935_add_admin_notes_to_request.exs
+++ b/apps/curbside_concerts/priv/repo/migrations/20200510001935_add_admin_notes_to_request.exs
@@ -1,0 +1,9 @@
+defmodule CurbsideConcerts.Repo.Migrations.AddAdminNotesToRequest do
+  use Ecto.Migration
+
+  def change do
+    alter table(:requests) do
+      add :admin_notes, :text
+    end
+  end
+end

--- a/apps/curbside_concerts_web/assets/css/app.scss
+++ b/apps/curbside_concerts_web/assets/css/app.scss
@@ -207,6 +207,10 @@ div#address_container {
 	}
 }
 
+.admin-notes-display {
+	white-space: pre;
+	font-style: italic;
+}
 
 .card.priority-request {
 	box-shadow: 0 0 5px purple;

--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/request/index.html.eex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/request/index.html.eex
@@ -31,10 +31,14 @@
       preferred_date: preferred_date,
       nominee_email: nominee_email,
       special_instructions: special_instructions,
-      requester_newsletter_interest: _newsletter_interest?
+      requester_newsletter_interest: _newsletter_interest?,
+      admin_notes: admin_notes
 		} = request <- @requests do %>
 
     <div class="card <%= if priority?, do: "priority-request" %>">
+      <%= if admin_notes do %>
+        <div class="admin-notes-display"><%= admin_notes %></div>
+      <% end %>
       <div><b>Preferred Date:</b> <%= preferred_date %></div>
       <div><b>Request Occasion:</b> <%= occasion %></div>
       <div><b>Request Reason:</b> <%= request_reason %></div>

--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/request/request_card.html.eex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/request/request_card.html.eex
@@ -24,9 +24,13 @@
   preferred_date: preferred_date,
   nominee_email: nominee_email,
   special_instructions: special_instructions,
-  requester_newsletter_interest: _newsletter_interest?
+  requester_newsletter_interest: _newsletter_interest?,
+  admin_notes: admin_notes
 } = @request %>
 <div class="card <%= if priority?, do: "priority-request" %>">
+  <%= if admin_notes do %>
+    <div class="admin-notes-display"><%= admin_notes %></div>
+  <% end %>
   <div><b>Preferred Date:</b> <%= preferred_date %></div>
   <div><b>Request Occasion:</b> <%= occasion %></div>
   <div><b>Request Reason:</b> <%= request_reason %></div>


### PR DESCRIPTION
From session booker, single-click a request to open the request viewer

The request viewer will have a texture for admin notes.

When the texture for admin notes is changes and focus leaves, the admin notes are updated on the request.

Requests cards will all display the admin notes, except for in the Driver Link and Musician Link pages.